### PR TITLE
Add support for deserializing responses with null data

### DIFF
--- a/src/deserialize/index.js
+++ b/src/deserialize/index.js
@@ -7,6 +7,8 @@ export const deserialize = (resp, options = {}) => {
 
   if (Array.isArray(data)) {
     deserialized = data.map((resource) => mapRelationships(resource, included));
+  } else if (data === null) {
+    deserialized = null;
   } else {
     deserialized = mapRelationships(data, included);
   }

--- a/src/deserialize/index.spec.js
+++ b/src/deserialize/index.spec.js
@@ -205,6 +205,10 @@ const expectRespWithSeparators = {
   errors: [{ title: "Error!" }],
 };
 
+const nullResp = {
+  data: null,
+};
+
 const util = require("util");
 
 describe("deserialize", () => {
@@ -215,6 +219,14 @@ describe("deserialize", () => {
 
     expect(resp).not.toEqual(result);
     expect(result).toEqual(expectedResponse);
+  });
+
+  it("deserializes null resource", async () => {
+    expect.assertions(1);
+
+    const result = deserialize(nullResp);
+
+    expect(nullResp).toEqual(result);
   });
 
   it("deserializes an array of resources", async () => {


### PR DESCRIPTION
As part of the JSON API spec, a single resource can be null. When passing null to deserialize, we try to call .relationships on it and it errors out. To fix this, a check was added to see if the data is null before trying to map the relationships. A new test was also added to test deserializing with a null payload.

From [JSON API spec](https://jsonapi.org/format/#document-top-level): 
<img width="726" alt="Screenshot 2023-06-15 at 12 53 55 PM" src="https://github.com/weilandia/deserialize-json-api/assets/4406751/0b14b448-cee6-4a8e-978c-c0e06cff81a0">
