### PR TITLE
Fixed crash when relationship object doesn't have data key

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ const deserializeResource = (resource, included, transformFunc) => {
 
   Object.keys(relationships).forEach(key => {
     const relationship = relationships[key].data;
+    if (!relationship) return;
     if (Array.isArray(relationship)) {
       deserialized[transformFunc ? transformFunc(key) : key] = relationship.map(rel => {
         const includedResource = findIncluded(included, rel.type, rel.id);

--- a/index.test.js
+++ b/index.test.js
@@ -39,6 +39,7 @@ const resp = {
       director: {
         data: { id: 1, type: "person" },
       },
+      studio: {}
     },
     links: {
       self: "/movies/1",


### PR DESCRIPTION
Regression bug appeared after upgrading the package to 2.0. It crashes when some relationship doesn't have `data` object, but with according to [JSON API spec](https://jsonapi.org/format/#document-resource-object-relationships) it should be possible such structure. For example:
```
"studio": {
  "links": {
    "self": "http://localhost:4000/api/rest/public/movies/1/relationships/studio",
    "related": "http://localhost:4000/api/rest/public/movies/1/studio"
  }
}
```